### PR TITLE
feat: content negotiation

### DIFF
--- a/API/CsvOutputFormatter.cs
+++ b/API/CsvOutputFormatter.cs
@@ -1,0 +1,49 @@
+using System.Text;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Net.Http.Headers;
+using Shared.DataTransferObjects;
+namespace API;
+
+public class CsvOutputFormatter : TextOutputFormatter
+{
+    public CsvOutputFormatter()
+    {
+        SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/csv"));
+        SupportedEncodings.Add(Encoding.UTF8);
+        SupportedEncodings.Add(Encoding.Unicode);
+    }
+
+    protected override bool CanWriteType(Type? type)
+    {
+        if (typeof(CustomersDto).IsAssignableFrom(type) ||
+        typeof(IEnumerable<CustomersDto>).IsAssignableFrom(type))
+        {
+            return base.CanWriteType(type);
+        }
+        return false;
+    }
+
+    public override async Task WriteResponseBodyAsync(OutputFormatterWriteContext context,
+    Encoding selectedEncoding)
+    {
+        var response = context.HttpContext.Response;
+        var buffer = new StringBuilder();
+
+        if (context.Object is IEnumerable<CustomersDto>)
+        {
+            foreach(var customer in (IEnumerable<CustomersDto>)context.Object)
+            {
+                FormatCsv(buffer, customer);
+            }
+        } else
+        {
+            FormatCsv(buffer, (CustomersDto)context.Object!);
+        }
+        await response.WriteAsync(buffer.ToString());
+    }
+
+    private static void FormatCsv(StringBuilder buffer, CustomersDto customer)
+    {
+        buffer.AppendLine($"{customer.Id},\"{customer.FirstName},\"{customer.LastName},\"{customer.Email},\"{customer.Address},\"{customer.PhoneNumber}\"");
+    }
+}

--- a/API/Extensions/ServiceExtensions.cs
+++ b/API/Extensions/ServiceExtensions.cs
@@ -33,4 +33,8 @@ public static class ServiceExtensions
     {
         services.AddScoped<IServiceManager, ServiceManager>();
     }
+
+    public static IMvcBuilder AddCustomCSVFormatter(this IMvcBuilder builder) =>
+    builder.AddMvcOptions(config => config.OutputFormatters.Add(new
+        CsvOutputFormatter()));
 }

--- a/API/Extensions/ServiceExtensions.cs
+++ b/API/Extensions/ServiceExtensions.cs
@@ -1,4 +1,3 @@
-using Contracts;
 using Contracts.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Repositories;

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -8,7 +8,10 @@ builder.Services.ConfigurePostgreSqlContext(builder.Configuration);
 builder.Services.ConfigureRepositoryManager();
 builder.Services.ConfigureServiceManager();
 builder.Services.AddAutoMapper(typeof(Program));
-builder.Services.AddControllers().AddApplicationPart(typeof(Presentation.AssemblyReference).Assembly);
+builder.Services.AddControllers(config => {
+    config.RespectBrowserAcceptHeader = true;
+}).AddXmlDataContractSerializerFormatters()
+.AddApplicationPart(typeof(Presentation.AssemblyReference).Assembly);
 builder.Services.ConfigureCors();
 builder.Services.ConfigureIISIntegration();
 builder.Services.AddEndpointsApiExplorer();

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -10,6 +10,7 @@ builder.Services.ConfigureServiceManager();
 builder.Services.AddAutoMapper(typeof(Program));
 builder.Services.AddControllers(config => {
     config.RespectBrowserAcceptHeader = true;
+    config.ReturnHttpNotAcceptable = true;
 }).AddXmlDataContractSerializerFormatters()
 .AddApplicationPart(typeof(Presentation.AssemblyReference).Assembly);
 builder.Services.ConfigureCors();

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddControllers(config => {
     config.RespectBrowserAcceptHeader = true;
     config.ReturnHttpNotAcceptable = true;
 }).AddXmlDataContractSerializerFormatters()
+.AddCustomCSVFormatter()
 .AddApplicationPart(typeof(Presentation.AssemblyReference).Assembly);
 builder.Services.ConfigureCors();
 builder.Services.ConfigureIISIntegration();

--- a/Shared/DataTransferObjects/CustomersDto.cs
+++ b/Shared/DataTransferObjects/CustomersDto.cs
@@ -1,10 +1,12 @@
 namespace Shared.DataTransferObjects;
 
-public record CustomersDto(
-    Guid Id,
-    string FirstName,
-    string LastName,
-    string Email,
-    string PhoneNumber,
-    string Address
-    );
+
+public record CustomersDto
+{
+    public Guid Id {get; init;}
+    public string? FirstName { get; init; }
+    public string? LastName { get; init; }
+    public string? Email { get; init; }
+    public string? PhoneNumber { get; init; }
+    public string? Address { get; init; }
+}


### PR DESCRIPTION
## Description
The client and server can now agree on the type of response the client can get

## Tasks done
- [x] Added xml format in the api response
- [x] Added restriction on the accept header. The client gets a 406 (not acceptable) error if the media type is not supported on the server
- [x] The default response (if accept header is not included) is json 
- [x] Added a custom CSV formatter. If the client sends text/csv in the Accept header, the response will be in csv
- [x] Screenshot/s:
![Screenshot 2024-11-18 at 3 15 22 PM](https://github.com/user-attachments/assets/e0ba5d65-a65c-43ce-989a-5671a8aee893)
![Screenshot 2024-11-18 at 3 32 22 PM](https://github.com/user-attachments/assets/02c1bc06-662f-4715-b0b4-ca2187347ffe)
![Screenshot 2024-11-18 at 3 37 47 PM](https://github.com/user-attachments/assets/3e0d68fa-67de-447f-ac80-16354524f305)
![Screenshot 2024-11-18 at 4 03 41 PM](https://github.com/user-attachments/assets/003c9db5-daf0-4feb-8de3-004a3c5f20e8)
 