### PR TITLE
feat: get all rooms

### DIFF
--- a/API/MappingProfile.cs
+++ b/API/MappingProfile.cs
@@ -3,6 +3,7 @@ using Entities.Models;
 using Shared.DataTransferObjects;
 using Shared.DataTransferObjects.Rooms;
 using Shared.DataTransferObjects.Users;
+using Shared.RequestFeatures;
 namespace API;
 
 public class MappingProfile : Profile
@@ -22,6 +23,24 @@ public class MappingProfile : Profile
         CreateMap<UpdateUserRequestDto, User>() //ignores the null values of the dto
             .ForAllMembers(opts => opts.Condition((src, dest, scrMember) => scrMember != null));
         CreateMap<CreateRoomRequestDto, Room>();
-        CreateMap<Room, RoomResponseDto>();
+        CreateMap<PagedList<Room>, IEnumerable<RoomResponseDto>>()
+            .ConvertUsing(list => list.Select(room => new RoomResponseDto
+            {
+                Id = room.Id,
+                Floor = room.Floor,
+                Number = room.Number,
+                RoomType = room.Type,
+                RoomStatus = room.Status,
+                Price_Per_Night = room.Price_Per_Night
+            }));
+        CreateMap<Room, RoomResponseDto>()
+            .ForMember(dest => dest.RoomType, opt =>
+            {
+                opt.MapFrom(src => src.Type.ToString());
+            })
+            .ForMember(dest => dest.RoomStatus, opt =>
+            {
+                opt.MapFrom(src => src.Type.ToString());
+            });
     }
 }

--- a/Contracts/Repositories/IRoom.cs
+++ b/Contracts/Repositories/IRoom.cs
@@ -1,7 +1,9 @@
 using Entities.Models;
+using Shared.RequestFeatures;
 namespace Contracts.Repositories;
 
 public interface IRoom
 {
     void CreateRoom(Room room);
+    Task<PagedList<Room>> GetAllRooms(RoomParameters roomParameters, bool trackChanges);
 }

--- a/Entities/Exceptions/FloorNotFoundException.cs
+++ b/Entities/Exceptions/FloorNotFoundException.cs
@@ -1,0 +1,7 @@
+namespace Entities.Exceptions;
+
+public class FloorNotFoundException : NotFoundException
+{
+    public FloorNotFoundException(int? FloorNumber): base($"floor number {FloorNumber} does not exsit")
+    {}
+}

--- a/Presentation/Controllers/RoomController.cs
+++ b/Presentation/Controllers/RoomController.cs
@@ -1,6 +1,8 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Service.Contracts;
 using Shared.DataTransferObjects.Rooms;
+using Shared.RequestFeatures;
 namespace Presentation.Controllers;
 
 [Route("/api/rooms")]
@@ -17,4 +19,16 @@ public class RoomController : ControllerBase
         return Ok(createdRoom);
     }
 
+    [HttpGet]
+    public async Task<IActionResult> GetAllRooms([FromQuery] RoomParameters roomParameters)
+    {
+        var (rooms, metaData) = await _service.RoomService.GetAllRooms(roomParameters, trackChanges: false);
+        var paginationHeader = JsonSerializer.Serialize(metaData);
+        Response.Headers.Add("X-Pagination", paginationHeader);
+        return Ok(new
+        {
+            Rooms = rooms,
+            MetaData = metaData
+        });
+    }
 }

--- a/Repositories/RoomRepository.cs
+++ b/Repositories/RoomRepository.cs
@@ -1,5 +1,7 @@
 using Contracts.Repositories;
 using Entities.Models;
+using Microsoft.EntityFrameworkCore;
+using Shared.RequestFeatures;
 namespace Repositories;
 
 public class RoomRepository : RepositoryBase<Room>, IRoom
@@ -8,4 +10,21 @@ public class RoomRepository : RepositoryBase<Room>, IRoom
     {}
 
     public void CreateRoom(Room room) => Create(room);
+
+    public async Task<PagedList<Room>> GetAllRooms(RoomParameters roomParameters, bool trackChanges)
+    {
+        var query = FindAll(trackChanges);
+        var totalRoom = await query.CountAsync();
+        if (roomParameters.FloorNumber.HasValue && roomParameters.FloorNumber > 0 && roomParameters.FloorNumber < 5)
+        {
+            query = query.Where(x => x.Floor == roomParameters.FloorNumber);
+            totalRoom = await query.Where(x => x.Floor == roomParameters.FloorNumber).CountAsync();
+        }
+        var rooms = await query
+            .OrderBy(x => x.Number)
+            .Skip((roomParameters.PageNumber - 1) * roomParameters.PageSize)
+            .Take(roomParameters.PageSize)
+            .ToListAsync();
+        return PagedList<Room>.ToPagedList(rooms, totalRoom, roomParameters.PageNumber, roomParameters.PageSize);
+    }
 }

--- a/Service.Contracts/IRoomService.cs
+++ b/Service.Contracts/IRoomService.cs
@@ -1,7 +1,10 @@
+using Entities.Models;
 using Shared.DataTransferObjects.Rooms;
+using Shared.RequestFeatures;
 namespace Service.Contracts;
 
 public interface IRoomService
 {
     Task<RoomResponseDto> CreateRoom(CreateRoomRequestDto createRoomRequestDto);
+    Task<(IEnumerable<RoomResponseDto>? rooms, MetaData metaData)> GetAllRooms(RoomParameters roomParameters, bool trackChanges);
 }

--- a/Services/RoomService.cs
+++ b/Services/RoomService.cs
@@ -1,7 +1,9 @@
 using AutoMapper;
 using Contracts.Repositories;
+using Entities.Exceptions;
 using Service.Contracts;
 using Shared.DataTransferObjects.Rooms;
+using Shared.RequestFeatures;
 namespace Services;
 
 internal sealed class RoomService : IRoomService
@@ -22,5 +24,14 @@ internal sealed class RoomService : IRoomService
         await _repository.SaveAsync();
         var responseDto = _mapper.Map<RoomResponseDto>(roomEntity);
         return responseDto;
+    }
+
+    public async Task<(IEnumerable<RoomResponseDto>? rooms, MetaData metaData)> GetAllRooms(RoomParameters roomParameters, bool trackChanges)
+    {
+        if (roomParameters.FloorNumber.HasValue && !roomParameters.ValidFloorNumber)
+            throw new FloorNotFoundException(roomParameters.FloorNumber);
+        var rooms = await _repository.Room.GetAllRooms(roomParameters, trackChanges);
+        var dto = _mapper.Map<IEnumerable<RoomResponseDto>>(rooms);
+        return (dto, rooms.MetaData);
     }
 }

--- a/Shared/RequestFeatures/RoomParameters.cs
+++ b/Shared/RequestFeatures/RoomParameters.cs
@@ -1,0 +1,7 @@
+namespace Shared.RequestFeatures;
+
+public class RoomParameters : RequestParameters
+{
+    public int? FloorNumber { get; set; }
+    public bool ValidFloorNumber => FloorNumber > 0 && FloorNumber < 5;
+}


### PR DESCRIPTION
## Description
Get all rooms endpoint with filtering by floor number 

## Tasks done:
- [x] Updated the room repository interface and repository implementation to add get-all-room method 
- [x] Updated the room service interface and service implementation to add get-all-room method 
- [x] Added filtering to get-all-rooms to filters the rooms by the floor
- [x] Created a no-floor-found exception to handle when the user tries to search for a floor less than 1 and bigger than 5  
- [x] Updated the mapping between the Room entity and RoomResponseDto to correctly handle the RoomType and RoomStatus enums
- [x] Screenshots:
- all rooms 
![Screenshot 2024-12-23 at 5 05 38 PM](https://github.com/user-attachments/assets/8a40d18f-2313-474a-8f2a-796918a48bd3)
- all rooms on floor 3 (* total count also changes in this case)
![Screenshot 2024-12-23 at 5 05 29 PM](https://github.com/user-attachments/assets/46da86a0-6225-488c-b2ad-c47ebb7bbed9)
 