### PR TITLE
feat: options and head http methods

### DIFF
--- a/Presentation/Controllers/CustomersController.cs
+++ b/Presentation/Controllers/CustomersController.cs
@@ -24,6 +24,7 @@ public class CustomersController : ControllerBase
     }
 
     [HttpGet]
+    [HttpHead]
     public async Task<IActionResult> GetCustomers([FromQuery] CustomerParameters customerParameters)
     {
         var (customers, metaData) = await _service.CustomerService.GetAllCustomers(customerParameters, trackChanges: false);

--- a/Presentation/Controllers/CustomersController.cs
+++ b/Presentation/Controllers/CustomersController.cs
@@ -5,6 +5,7 @@ using Shared.DataTransferObjects;
 using Shared.RequestFeatures;
 namespace Presentation.Controllers;
 
+
 [Route("api/customers")]
 [ApiController]
 public class CustomersController : ControllerBase

--- a/Presentation/Controllers/CustomersController.cs
+++ b/Presentation/Controllers/CustomersController.cs
@@ -42,4 +42,11 @@ public class CustomersController : ControllerBase
         var customer = await _service.CustomerService.GetCustomer(id, trackChanges: false);
         return Ok(customer);
     }
+
+    [HttpOptions]
+    public IActionResult GetCustomersOptions()
+    {
+        Response.Headers.Add("Allow", "GET, OPTIONS, POST");
+        return Ok();
+    }
 }


### PR DESCRIPTION
## Descriptions 
Added an options endpoint for customers to return in the response headers all the allowed methods for the URI. Also added an http head attribute for getting all customers endpoint HEAD/GET /api/customers

## Screenshots:
![Screenshot 2025-01-15 at 5 59 32 PM](https://github.com/user-attachments/assets/d78ae8f0-556b-4f4e-9fb5-277d854a3007)

![Screenshot 2025-01-15 at 6 00 25 PM](https://github.com/user-attachments/assets/ee5cc192-fff5-409f-a451-b0b49b94508d)

![Screenshot 2025-01-15 at 6 03 24 PM](https://github.com/user-attachments/assets/3397c9bc-3396-4ffe-bdb4-9cc03f178852)
